### PR TITLE
Fix navbar styling issues

### DIFF
--- a/src/components/Navbar/DesktopNavbar.tsx
+++ b/src/components/Navbar/DesktopNavbar.tsx
@@ -16,7 +16,7 @@ export const DesktopNavbar = ({ items }: DesktopNavbarProps) => {
           "linear-gradient(to bottom, black 0%, black 50%, transparent 100%)",
       }}
     >
-      <div className=" flex w-full justify-between items-center pt-2 border-b-orange-50 border-b-1 py-3">
+      <div className="flex w-full justify-between items-center border-b-orange-50 border-b-1 py-3">
         <NavLink href={"/#hero-section"} className="text-3xl font-bold hover:text-amber-500">
           AGROSKEN
         </NavLink>

--- a/src/components/Navbar/MobileNavbar.tsx
+++ b/src/components/Navbar/MobileNavbar.tsx
@@ -13,7 +13,7 @@ export const MobileNavbar = ({ items }: MobileNavbarProps) => {
   return (
     <>
       <div
-        className="fixed pt-8 w-full navbar z-50 pb-0"
+        className="fixed pt-4 w-full navbar z-50 pb-0"
         style={{
           maskImage:
             "linear-gradient(to bottom, #302424 0%, black 80%, transparent 100%)",
@@ -29,7 +29,7 @@ export const MobileNavbar = ({ items }: MobileNavbarProps) => {
             AGROSKEN
           </NavLink>
           <Bars3CenterLeftIcon
-            className="rotate-180 max-h-10"
+            className="rotate-180 max-h-10 text-white cursor-pointer"
             onClick={() => setIsOpen(true)}
           />
         </div>
@@ -48,7 +48,7 @@ export const MobileNavbar = ({ items }: MobileNavbarProps) => {
             AGROSKEN
           </NavLink>
           <XMarkIcon
-            className="rotate-180 max-h-10"
+            className="rotate-180 max-h-10 text-white cursor-pointer"
             onClick={() => setIsOpen(false)}
           />
         </div>


### PR DESCRIPTION
## Summary
- Fixed mobile menu icons to be white instead of black
- Reduced excessive top padding on the navbar
- Added cursor-pointer style for better UX on clickable icons

## Changes
- Added `text-white` class to hamburger menu and close icons
- Added `cursor-pointer` class to clickable icons
- Reduced mobile navbar top padding from `pt-8` to `pt-4`
- Removed unnecessary `pt-2` from desktop navbar

## Test plan
- [x] Verified icons are now white on mobile
- [x] Confirmed reduced padding looks better
- [x] Build passes successfully
- [x] Tested mobile and desktop views