### PR TITLE
Add Google Analytics (G-P4L3MQWP1F)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["github"],
+  "permissions": {
+    "allow": ["Bash(open:*)"]
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/index.html
+++ b/index.html
@@ -2,6 +2,20 @@
 <html lang="cs">
   <head>
     <meta charset="UTF-8" />
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-P4L3MQWP1F"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-P4L3MQWP1F");
+    </script>
     <link rel="icon" type="image/svg+xml" href="/drone-icon.svg" />
     <meta
       name="viewport"

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -9,7 +9,7 @@ export const Hero = () => {
   const textRef = useRef<HTMLDivElement>(null);
   const [chevronAnimationOffset, setChevronAnimationOffset] = useState(0);
   const [isHovered, setIsHovered] = useState(false);
-  
+
   const buttonAnimationDelay = 0.7 + title.length * 0.03;
 
   useEffect(() => {
@@ -68,15 +68,17 @@ export const Hero = () => {
           onMouseLeave={() => setIsHovered(false)}
         >
           <div className="absolute inset-0 -left-2 -right-2 bg-[var(--color-primary-amber)] rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
-          <div 
+          <div
             className="relative bg-[var(--color-primary-amber)] h-full aspect-square rounded-full flex items-center justify-center font-bold transition-all duration-500 group-hover:bg-transparent z-10"
             style={{
-              transform: isHovered ? `translateX(${chevronAnimationOffset}px)` : 'translateX(0px)',
+              transform: isHovered
+                ? `translateX(${chevronAnimationOffset}px)`
+                : "translateX(0px)",
             }}
           >
             <ChevronRightIcon className="h-5 w-5" />
           </div>
-          <div 
+          <div
             ref={textRef}
             className="relative text-lg font-bold transition-all duration-500 group-hover:-translate-x-8 z-10"
           >

--- a/src/components/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy/PrivacyPolicy.tsx
@@ -1,54 +1,85 @@
 import { motion } from "framer-motion";
 
 const PrivacyPolicy = () => {
-
   const czechSections = [
     {
       title: "1. Úvod",
-      content: "Respektujeme vaše soukromí. Tyto Zásady ochrany osobních údajů vysvětlují, jak společnost Agrosken (\"my\", \"nás\", \"náš\") shromažďuje, používá a chrání vaše osobní údaje, když odešlete formulář na našich webových stránkách nebo využijete naše služby."
+      content:
+        'Respektujeme vaše soukromí. Tyto Zásady ochrany osobních údajů vysvětlují, jak společnost Agrosken ("my", "nás", "náš") shromažďuje, používá a chrání vaše osobní údaje, když odešlete formulář na našich webových stránkách nebo využijete naše služby.',
     },
     {
       title: "2. Informace, které shromažďujeme",
       content: (
         <>
-          Následující osobní údaje shromažďujeme <strong>pouze</strong> při dobrovolném poskytnutí prostřednictvím našeho kontaktního/projektového formuláře:
+          Následující osobní údaje shromažďujeme <strong>pouze</strong> při
+          dobrovolném poskytnutí prostřednictvím našeho kontaktního/projektového
+          formuláře:
           <ul className="list-disc ml-6 mt-2 space-y-1">
-            <li><strong>Jméno</strong></li>
-            <li><strong>E-mailová adresa</strong></li>
-            <li><strong>Telefonní číslo</strong></li>
-            <li><strong>Podrobnosti o projektu</strong> (popis, rozsah nebo jiné informace, které sdílíte)</li>
+            <li>
+              <strong>Jméno</strong>
+            </li>
+            <li>
+              <strong>E-mailová adresa</strong>
+            </li>
+            <li>
+              <strong>Telefonní číslo</strong>
+            </li>
+            <li>
+              <strong>Podrobnosti o projektu</strong> (popis, rozsah nebo jiné
+              informace, které sdílíte)
+            </li>
           </ul>
           <p className="mt-4">
-            <strong>Neshromažďujeme</strong> žádné informace prostřednictvím cookies, analytických nástrojů, sledovacích pixelů nebo jiných pasivních metod.
+            <strong>Neshromažďujeme</strong> žádné informace prostřednictvím
+            cookies, analytických nástrojů, sledovacích pixelů nebo jiných
+            pasivních metod.
           </p>
         </>
-      )
+      ),
     },
     {
       title: "3. Jak používáme vaše informace",
       content: (
         <ul className="list-disc ml-6 space-y-2">
-          <li><strong>K odpovědi na váš dotaz</strong> a následné komunikaci ohledně vašeho projektu.</li>
-          <li><strong>K předávání důležitých aktualizací nebo objasnění</strong> týkajících se vašeho podání.</li>
-          <li><strong>Neposíláme</strong> marketingové nebo propagační komunikace, pokud o to výslovně nepožádáte.</li>
+          <li>
+            <strong>K odpovědi na váš dotaz</strong> a následné komunikaci
+            ohledně vašeho projektu.
+          </li>
+          <li>
+            <strong>K předávání důležitých aktualizací nebo objasnění</strong>{" "}
+            týkajících se vašeho podání.
+          </li>
+          <li>
+            <strong>Neposíláme</strong> marketingové nebo propagační komunikace,
+            pokud o to výslovně nepožádáte.
+          </li>
         </ul>
-      )
+      ),
     },
     {
       title: "4. Sdílení údajů",
       content: (
         <>
-          Vaše osobní údaje nikdy nesdílíme s třetími stranami, kromě případů kdy:
+          Vaše osobní údaje nikdy nesdílíme s třetími stranami, kromě případů
+          kdy:
           <ul className="list-disc ml-6 mt-2 space-y-1">
-            <li><strong>To vyžaduje zákon</strong>, pro právní soulad nebo ochranu práv, nebo</li>
-            <li><strong>Pro splnění služby</strong>, kterou jste výslovně požádali (např. předání vašeho projektu určenému spolupracovníkovi), s oznámením.</li>
+            <li>
+              <strong>To vyžaduje zákon</strong>, pro právní soulad nebo ochranu
+              práv, nebo
+            </li>
+            <li>
+              <strong>Pro splnění služby</strong>, kterou jste výslovně požádali
+              (např. předání vašeho projektu určenému spolupracovníkovi), s
+              oznámením.
+            </li>
           </ul>
         </>
-      )
+      ),
     },
     {
       title: "5. Uchovávání údajů",
-      content: "Vaše informace uchováváme pouze tak dlouho, jak je nezbytné pro zpracování vašeho podání a jakékoli následné komunikace. Pokud si přejete smazat své informace, kontaktujte nás (podrobnosti níže)."
+      content:
+        "Vaše informace uchováváme pouze tak dlouho, jak je nezbytné pro zpracování vašeho podání a jakékoli následné komunikace. Pokud si přejete smazat své informace, kontaktujte nás (podrobnosti níže).",
     },
     {
       title: "6. Vaše práva",
@@ -56,35 +87,57 @@ const PrivacyPolicy = () => {
         <>
           Kdykoli můžete:
           <ul className="list-disc ml-6 mt-2 space-y-1">
-            <li>Požádat o přístup k vašim osobním údajům nebo jejich smazání.</li>
+            <li>
+              Požádat o přístup k vašim osobním údajům nebo jejich smazání.
+            </li>
             <li>Požádat o opravu jakýchkoli nepřesností ve vašich údajích.</li>
           </ul>
           <p className="mt-4">
-            Pro uplatnění těchto práv nás prosím kontaktujte pomocí níže uvedených informací.
+            Pro uplatnění těchto práv nás prosím kontaktujte pomocí níže
+            uvedených informací.
           </p>
         </>
-      )
+      ),
     },
     {
       title: "7. Bezpečnost",
-      content: "Implementujeme rozumná administrativní, technická a fyzická opatření k ochraně vašich osobních údajů. Žádný bezpečnostní systém však není zcela neproniknutelný."
+      content:
+        "Implementujeme rozumná administrativní, technická a fyzická opatření k ochraně vašich osobních údajů. Žádný bezpečnostní systém však není zcela neproniknutelný.",
     },
     {
       title: "8. Změny těchto zásad",
-      content: "Tyto Zásady ochrany osobních údajů můžeme příležitostně aktualizovat. Jakékoli změny budou zveřejněny zde s novým \"Datem účinnosti\". Doporučujeme je pravidelně kontrolovat."
+      content:
+        'Tyto Zásady ochrany osobních údajů můžeme příležitostně aktualizovat. Jakékoli změny budou zveřejněny zde s novým "Datem účinnosti". Doporučujeme je pravidelně kontrolovat.',
     },
     {
       title: "9. Kontaktujte nás",
       content: (
         <>
-          Máte-li jakékoli otázky ohledně těchto zásad nebo vašich osobních údajů, kontaktujte nás na:
+          Máte-li jakékoli otázky ohledně těchto zásad nebo vašich osobních
+          údajů, kontaktujte nás na:
           <div className="mt-4 space-y-2">
-            <p><strong>E-mail:</strong> <a href="mailto:kriz@agrosken.cz" className="text-blue-400 hover:text-blue-300 underline">kriz@agrosken.cz</a></p>
-            <p><strong>Telefon:</strong> <a href="tel:+420773640132" className="text-blue-400 hover:text-blue-300 underline">+420 773 640 132</a></p>
+            <p>
+              <strong>E-mail:</strong>{" "}
+              <a
+                href="mailto:kriz@agrosken.cz"
+                className="text-blue-400 hover:text-blue-300 underline"
+              >
+                kriz@agrosken.cz
+              </a>
+            </p>
+            <p>
+              <strong>Telefon:</strong>{" "}
+              <a
+                href="tel:+420773640132"
+                className="text-blue-400 hover:text-blue-300 underline"
+              >
+                +420 773 640 132
+              </a>
+            </p>
           </div>
         </>
-      )
-    }
+      ),
+    },
   ];
 
   return (
@@ -121,7 +174,7 @@ const PrivacyPolicy = () => {
                 {section.title}
               </h2>
               <div className="text-gray-300 leading-relaxed text-lg">
-                {typeof section.content === 'string' ? (
+                {typeof section.content === "string" ? (
                   <p>{section.content}</p>
                 ) : (
                   section.content
@@ -151,37 +204,68 @@ const PrivacyPolicy = () => {
               const getEnglishContent = (section: number) => {
                 switch (section) {
                   case 1:
-                    return "We respect your privacy. This Privacy Policy explains how Agrosken (\"we\", \"us\", \"our\") collects, uses, and protects your personal information when you submit a form on our website or interact with our services.";
+                    return 'We respect your privacy. This Privacy Policy explains how Agrosken ("we", "us", "our") collects, uses, and protects your personal information when you submit a form on our website or interact with our services.';
                   case 2:
                     return (
                       <>
-                        We collect the following personal information <strong>only</strong> when voluntarily provided via our contact/project submission form:
+                        We collect the following personal information{" "}
+                        <strong>only</strong> when voluntarily provided via our
+                        contact/project submission form:
                         <ul className="list-disc ml-6 mt-2 space-y-1">
-                          <li><strong>Name</strong></li>
-                          <li><strong>Email Address</strong></li>
-                          <li><strong>Phone Number</strong></li>
-                          <li><strong>Project Details</strong> (description, scope, or other information you share)</li>
+                          <li>
+                            <strong>Name</strong>
+                          </li>
+                          <li>
+                            <strong>Email Address</strong>
+                          </li>
+                          <li>
+                            <strong>Phone Number</strong>
+                          </li>
+                          <li>
+                            <strong>Project Details</strong> (description,
+                            scope, or other information you share)
+                          </li>
                         </ul>
                         <p className="mt-4">
-                          We do <strong>not</strong> collect any information via cookies, analytics tools, tracking pixels, or other passive methods.
+                          We do <strong>not</strong> collect any information via
+                          cookies, analytics tools, tracking pixels, or other
+                          passive methods.
                         </p>
                       </>
                     );
                   case 3:
                     return (
                       <ul className="list-disc ml-6 space-y-2">
-                        <li>To respond to your inquiry and follow up about your project.</li>
-                        <li>To communicate important updates or clarifications regarding your submission.</li>
-                        <li>We do <strong>not</strong> send marketing or promotional communications, unless explicitly requested by you.</li>
+                        <li>
+                          To respond to your inquiry and follow up about your
+                          project.
+                        </li>
+                        <li>
+                          To communicate important updates or clarifications
+                          regarding your submission.
+                        </li>
+                        <li>
+                          We do <strong>not</strong> send marketing or
+                          promotional communications, unless explicitly
+                          requested by you.
+                        </li>
                       </ul>
                     );
                   case 4:
                     return (
                       <>
-                        We never share your personal information with third parties, unless:
+                        We never share your personal information with third
+                        parties, unless:
                         <ul className="list-disc ml-6 mt-2 space-y-1">
-                          <li>Required by law, for legal compliance or protection of rights, or</li>
-                          <li>To fulfill a service you've explicitly requested (e.g., forwarding your project to a specified collaborator), with notification.</li>
+                          <li>
+                            Required by law, for legal compliance or protection
+                            of rights, or
+                          </li>
+                          <li>
+                            To fulfill a service you've explicitly requested
+                            (e.g., forwarding your project to a specified
+                            collaborator), with notification.
+                          </li>
                         </ul>
                       </>
                     );
@@ -192,25 +276,49 @@ const PrivacyPolicy = () => {
                       <>
                         You may, at any time:
                         <ul className="list-disc ml-6 mt-2 space-y-1">
-                          <li>Request access to or deletion of your personal information.</li>
-                          <li>Request corrections to any inaccuracies in your data.</li>
+                          <li>
+                            Request access to or deletion of your personal
+                            information.
+                          </li>
+                          <li>
+                            Request corrections to any inaccuracies in your
+                            data.
+                          </li>
                         </ul>
                         <p className="mt-4">
-                          To exercise these rights, please contact us using the information below.
+                          To exercise these rights, please contact us using the
+                          information below.
                         </p>
                       </>
                     );
                   case 7:
                     return "We implement reasonable administrative, technical, and physical safeguards to protect your personal information. However, no security system is completely impenetrable.";
                   case 8:
-                    return "We may update this Privacy Policy occasionally. Any changes will be posted here with a new \"Effective Date.\" We encourage you to review it periodically.";
+                    return 'We may update this Privacy Policy occasionally. Any changes will be posted here with a new "Effective Date." We encourage you to review it periodically.';
                   case 9:
                     return (
                       <>
-                        If you have any questions about this policy or your personal information, please contact us at:
+                        If you have any questions about this policy or your
+                        personal information, please contact us at:
                         <div className="mt-4 space-y-2">
-                          <p><strong>Email:</strong> <a href="mailto:kriz@agrosken.cz" className="text-blue-400 hover:text-blue-300 underline">kriz@agrosken.cz</a></p>
-                          <p><strong>Phone:</strong> <a href="tel:+420773640132" className="text-blue-400 hover:text-blue-300 underline">+420 773 640 132</a></p>
+                          <p>
+                            <strong>Email:</strong>{" "}
+                            <a
+                              href="mailto:kriz@agrosken.cz"
+                              className="text-blue-400 hover:text-blue-300 underline"
+                            >
+                              kriz@agrosken.cz
+                            </a>
+                          </p>
+                          <p>
+                            <strong>Phone:</strong>{" "}
+                            <a
+                              href="tel:+420773640132"
+                              className="text-blue-400 hover:text-blue-300 underline"
+                            >
+                              +420 773 640 132
+                            </a>
+                          </p>
                         </div>
                       </>
                     );
@@ -229,7 +337,7 @@ const PrivacyPolicy = () => {
                   6: "6. Your Rights",
                   7: "7. Security",
                   8: "8. Changes to This Policy",
-                  9: "9. Contact Us"
+                  9: "9. Contact Us",
                 };
                 return titles[section as keyof typeof titles];
               };
@@ -240,7 +348,7 @@ const PrivacyPolicy = () => {
                     {getEnglishTitle(sectionNum)}
                   </h2>
                   <div className="text-gray-500 leading-relaxed">
-                    {typeof getEnglishContent(sectionNum) === 'string' ? (
+                    {typeof getEnglishContent(sectionNum) === "string" ? (
                       <p>{getEnglishContent(sectionNum)}</p>
                     ) : (
                       getEnglishContent(sectionNum)

--- a/src/components/ServiceCard/ServiceCard.tsx
+++ b/src/components/ServiceCard/ServiceCard.tsx
@@ -15,7 +15,7 @@ export const ServiceCard = ({
     >
       <div className="flex flex-col gap-8 flex-1">
         <div className="flex min-h-10 h-auto gap-4 items-center text-5xl">
-          <Icon className="h-10 w-10 min-w-10" fontSize="inherit"/>
+          <Icon className="h-10 w-10 min-w-10" fontSize="inherit" />
           <div className="text-xl md:text-3xl font-bold">{title}</div>
         </div>
         <div className="text-justify">{description}</div>

--- a/src/components/Services/Services.tsx
+++ b/src/components/Services/Services.tsx
@@ -19,9 +19,9 @@ export const Services = () => {
       </div>
 
       <div className="max-w-full h-auto">
-        <ServiceCard 
-          service={services[activeServiceIndex]} 
-          reverseOrder={(activeServiceIndex + 1) % 2 === 0} 
+        <ServiceCard
+          service={services[activeServiceIndex]}
+          reverseOrder={(activeServiceIndex + 1) % 2 === 0}
         />
       </div>
 

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -4,19 +4,15 @@ import weedDetection from "../assets/services/weed-detection.jpg";
 import prescriptionMaps from "../assets/services/prescription-maps.jpg";
 import aerialSpraying from "../assets/services/aerial-spraying.jpg";
 import insuranceDocumentation from "../assets/services/insurance-documentation.jpg";
-import {
-
-  CloudIcon,
-  DocumentTextIcon,
-} from "@heroicons/react/24/solid";
-import MapOutlinedIcon from '@mui/icons-material/MapOutlined';
-import GrassOutlinedIcon from '@mui/icons-material/GrassOutlined';
-import HealthAndSafetyOutlinedIcon from '@mui/icons-material/HealthAndSafetyOutlined';
+import { CloudIcon, DocumentTextIcon } from "@heroicons/react/24/solid";
+import MapOutlinedIcon from "@mui/icons-material/MapOutlined";
+import GrassOutlinedIcon from "@mui/icons-material/GrassOutlined";
+import HealthAndSafetyOutlinedIcon from "@mui/icons-material/HealthAndSafetyOutlined";
 import { useMessage } from "../locales/LocaleHooks";
 
 export interface Service {
   id: string;
-  icon: ComponentType<{ className?: string, fontSize: "inherit" }>;
+  icon: ComponentType<{ className?: string; fontSize: "inherit" }>;
   title: string;
   description: string;
   imageSrc: string;

--- a/src/hooks/mutations/useUpdateEmailSent.tsx
+++ b/src/hooks/mutations/useUpdateEmailSent.tsx
@@ -35,7 +35,9 @@ export const useUpdateEmailSent = (authKey: string) => {
   return useMutation({
     mutationFn: updateEmailSent,
     onMutate: async ({ id, emailSent }) => {
-      await queryClient.cancelQueries({ queryKey: ["contactRequest", authKey] });
+      await queryClient.cancelQueries({
+        queryKey: ["contactRequest", authKey],
+      });
 
       const previousData = queryClient.getQueryData<ContactRequestResponse[]>([
         "contactRequest",

--- a/src/providers/LocaleProvider.tsx
+++ b/src/providers/LocaleProvider.tsx
@@ -27,8 +27,8 @@ const defaultLocale: Locale = "cs-CZ";
 
 const getInitialLocale = (): Locale => {
   const storedLocale = localStorage.getItem(LOCAL_STORAGE_KEY) as Locale;
-  return storedLocale && Object.keys(messages).includes(storedLocale) 
-    ? storedLocale 
+  return storedLocale && Object.keys(messages).includes(storedLocale)
+    ? storedLocale
     : defaultLocale;
 };
 


### PR DESCRIPTION
## Summary
- Add GA4 gtag.js snippet to `index.html` for measurement ID `G-P4L3MQWP1F`.
- Bundled Prettier reformatting across `src/components/**`, `src/data/services.ts`, `src/providers/LocaleProvider.tsx`, `src/hooks/mutations/useUpdateEmailSent.tsx`, and `.github/workflows/build.yml` (no behavior change — picked up by `npm run format`).
- Adds `.claude/settings.local.json` (local Claude config — flag if this should stay out of the repo).

## Test plan
- [ ] `npm run build` passes locally.
- [ ] After deploy, GA4 Realtime report shows a session when visiting the site.
- [ ] Smoke-check Hero, Services, ServiceCard, and PrivacyPolicy pages render unchanged.